### PR TITLE
feat: set the FastApi root_path via environment variable

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
+        fetch-depth: '0'
         lfs: 'true'
     - uses: actions/setup-python@v5
       with:

--- a/src/aws/osml/tile_server/app_config.py
+++ b/src/aws/osml/tile_server/app_config.py
@@ -1,4 +1,4 @@
-#  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2023-2025 Amazon.com, Inc. or its affiliates.
 
 import logging
 import os
@@ -30,6 +30,7 @@ class ServerConfig:
     efs_mount_name: str = os.getenv("EFS_MOUNT_NAME", "ts-efs-volume")
     sts_arn: str = os.getenv("STS_ARN", None)
     ddb_ttl_days: int = os.getenv("DDB_TTL_DAYS", 1)
+    api_root_path: str = os.getenv("FASTAPI_ROOT_PATH", "")
     tile_server_log_level = logging.INFO
 
     OVERVIEW_FILE_EXTENSION = ".ovr"

--- a/src/aws/osml/tile_server/main.py
+++ b/src/aws/osml/tile_server/main.py
@@ -1,4 +1,4 @@
-#  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2023-2025 Amazon.com, Inc. or its affiliates.
 
 import logging
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
@@ -110,6 +110,7 @@ app = VersionedFastAPI(
         "name": "Amazon Web Services",
     },
     lifespan=lifespan,
+    root_path=ServerConfig.api_root_path,
 )
 app.add_middleware(
     CORSMiddleware,
@@ -141,8 +142,8 @@ async def root() -> str:
             <p>{app.description}.</p>
             <p>If you need help or support,
                 please cut an issue ticket <a href="{app.contact["url"]}">in our github project</a>.</p>
-            <p><a href="/latest/docs">Swagger</a></p>
-            <p><a href="/latest/redoc">ReDoc</a></p>
+            <p><a href="{ServerConfig.api_root_path}/latest/docs">Swagger</a></p>
+            <p><a href="{ServerConfig.api_root_path}/latest/redoc">ReDoc</a></p>
             <p>The license of this product: {app.license_info["license"]}</p>
         </body>
     </html>

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ commands =
 skip_install = true
 conda_env =
 deps = pre-commit
-commands = pre-commit run --all-files --show-diff-on-failure
+commands = pre-commit run --from-ref origin/main --to-ref HEAD
 
 [testenv:docs]
 changedir = doc


### PR DESCRIPTION
**Issue #, if available:** n/a

### Notes
This adds the ability to set the FastApi root_path via environment variable which avoids a code change in cases where Tile Server is deployed behind a proxy.  root_path defaults to an empty string if not set.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
